### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.cubocore.CoreTime.yml
+++ b/org.cubocore.CoreTime.yml
@@ -13,7 +13,6 @@ finish-args:
   - --filesystem=home # Storing weather data
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
-  - --own-name=org.kde.* # For showing in the system tray
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025